### PR TITLE
[TASK] Align release packaging and repository metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.ddev/ export-ignore
+/.github/ export-ignore
+/Build/ export-ignore
+/Tests/ export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/composer.json
+++ b/composer.json
@@ -173,15 +173,9 @@
       "rm -rf .github",
       "rm -rf Build",
       "rm -rf Tests",
-      "rm -rf tools",
       "rm .editorconfig",
       "rm .gitattributes",
-      "rm .gitignore",
-      "rm .npmrc",
-      "rm .nvmrc",
-      "rm package-lock.json",
-      "rm package.json",
-      "rm phive.xml"
+      "rm .gitignore"
     ],
     "rebuild-libs": [
       "rm -f Libraries/simplepie-simplepie.phar",


### PR DESCRIPTION
Align prepare-release, .gitattributes and .gitignore to keep development-only files out of release artifacts and version control.

Remove inconsistencies between ignored files and exported files and streamline the repository housekeeping for extension releases.